### PR TITLE
Weight random memory choice towards earlier ones

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -70,7 +70,7 @@
 	{/if}
 	{#if memoryIsOpen}
 		<Memory
-			memory={$memories[Math.floor(Math.random() * $memories.length)]}
+			memory={$memories[Math.floor(Math.pow(Math.random(), 1.3) * $memories.length)]}
 			close={closeMemory}
 			dele={deleteMemory}
 		></Memory>


### PR DESCRIPTION
In relation to my comments in issue #4, here is my idea for weighting the Recall Memory aspect of Nostalgia towards earlier memories (those at lower indexes in the memories array). After some experimentation, I settled on a relatively subtle 1.3 power for the weighting but this can be increased to make it more obvious if desired.